### PR TITLE
Fix overview power sensor unit conversion

### DIFF
--- a/custom_components/hypontech/sensor.py
+++ b/custom_components/hypontech/sensor.py
@@ -41,7 +41,7 @@ OVERVIEW_SENSORS: tuple[HypontechSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda c: c.power,
+        value_fn=lambda c: c.power * 1000 if c.company == "KW" else c.power,
     ),
     HypontechSensorDescription(
         key="lifetime_energy",


### PR DESCRIPTION
## Summary
- The Hypontech Cloud API dynamically changes the power unit from W to KW (indicated by the `company` field in the response) when the value exceeds 1000W
- The overview power sensor was ignoring the `company` field, causing e.g. 1 KW to be displayed as 1 W
- The fix checks `company` and converts to watts when the API returns KW

## Test plan
- [ ] Verify overview power sensor shows correct values when production exceeds 1000W
- [ ] Verify overview power sensor still works correctly for values below 1000W

🤖 Generated with [Claude Code](https://claude.com/claude-code)